### PR TITLE
Correction de l'url d'un script...

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>GW2 API Explorer</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script type="text/javascript" src="http://code.jquery.com/jquery-2.1.4.min.js"></script>
-  <script type="application/javascript; version=1.7" src="https://raw.githubusercontent.com/nmss/gw2-api-wrapper/master/gw2-api-wrapper.js"></script>
+  <script type="text/javascript" src="https://rawgit.com/nmss/gw2-api-wrapper/master/gw2-api-wrapper.js"></script>
   <script type="text/javascript" src="script.js"></script>
 </head>
 <body>


### PR DESCRIPTION
…depuis que github le renvoie avec le type "text/plain", pour que ça fonctionne sous chrome aussi

cf http://stackoverflow.com/questions/17341122/link-and-execute-external-javascript-file-hosted-on-github

de plus j'ai supprimé les `let` qui forçaient firefox a utiliser le type "application/javascript;version=1.7" donc hop plus besoin de ça
